### PR TITLE
Add missing COPY of settings.json file into Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,7 @@ RUN apk update && apk upgrade && \
 COPY sporttracker/ /opt/SportTracker/sporttracker
 COPY CHANGES.md /opt/SportTracker/CHANGES.md
 COPY --from=poetry /opt/SportTracker/myvenv /opt/SportTracker/myvenv
+COPY settings.json /opt/SportTracker/settings.json
 
 RUN adduser -D sporttracker && chown -R sporttracker:sporttracker /opt/SportTracker
 USER sporttracker


### PR DESCRIPTION
Hi and thank you so much for this great piece of software that SportTracker is!
After building and running the container image from the Dockerfile, there was an error message stating that the settings.json file was missing. Adding the corresponding line to the Dockerfile fixed it for me. Or did I miss anything and the not copying settings.json into the image was intentional?