### PR TITLE
Add Docker Compose

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,7 @@ RUN apk update && apk upgrade && \
 COPY sporttracker/ /opt/SportTracker/sporttracker
 COPY CHANGES.md /opt/SportTracker/CHANGES.md
 COPY --from=poetry /opt/SportTracker/myvenv /opt/SportTracker/myvenv
+COPY settings.json /opt/SportTracker/settings.json
 
 RUN adduser -D sporttracker && chown -R sporttracker:sporttracker /opt/SportTracker
 USER sporttracker

--- a/README.md
+++ b/README.md
@@ -153,7 +153,14 @@ The corresponding swagger-ui is available at `/api/v2/docs`
 2. Copy `settings-example.json` to `settings.json` and adjust to your configuration
 3. Run the server: `<path_to_python_executable_in_poetry_venv> src/SportTracker.py` 
 
-💡 Or use the docker image.
+## Docker
+1. In the `docker-compose.yaml` change `POSTGRES_USER` and `POSTGRES_PASSWORD`.
+2. Copy `settings-example.json` to `settings.json` and adjust to your configuration. It is recommended to change the value of `server:secret`. Also adjust the database URI and set `sporttracker-user` and `sporttracker-password` to match the values in the `docker-compose.yaml`.
+3. Build and run the container using `docker compose up --build`.
+4. Observe the console output for the admin password that is generated during the initialization of the container.
+5. You should be able to access the server on localhost:10022
+
+
 
 ## Command line arguments
 - `--debug`, `-d` = Enable debug mode

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,38 @@
+version: '3.8'
+services:
+  postgres:
+    image: postgres
+    container_name: sporttracker-postgres
+    environment:
+      POSTGRES_USER: sporttracker-user
+      POSTGRES_PASSWORD: sporttracker-password
+      POSTGRES_DB: sporttracker-db
+    networks:
+      - app-network
+    ports:
+      - "5432:5432"
+    volumes:
+      - ./postgres_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U sporttracker-user -d sporttracker-db -t 1"]
+      interval: 10s
+      timeout: 10s
+      retries: 10
+      start_period: 10s
+
+  flask:
+    container_name: sporttracker-app
+    build:
+      context: .
+      dockerfile: Dockerfile
+    ports:
+      - 10022:10022
+    networks:
+      - app-network
+    depends_on:
+      postgres:
+        condition: service_healthy
+
+networks:
+  app-network:
+    driver: bridge

--- a/settings-example.json
+++ b/settings-example.json
@@ -2,7 +2,7 @@
     "server": {
         "listen": "0.0.0.0",
         "port": 10022,
-        "secret": "",
+        "secret": "secret",
         "useSSL": false,
         "keyfile": "",
         "certfile": ""
@@ -14,7 +14,7 @@
         "numberOfBackups": 3
     },
     "database": {
-        "uri": "postgresql://username:password@localhost:5432/your_database"
+        "uri": "postgresql://sporttracker-user:sporttracker-password@postgres:5432/sporttracker-db"
     },
     "gpxPreviewImages": {
         "enabled": false,


### PR DESCRIPTION
Thank you for providing a docker file for easy deployment!
Initially I had some trouble running the container. The SportTracker.py error log was reporting that it could not access the database. I see that `postgresql-dev` and `postgresql-libs` are added to the container image, but I wasn't able start the database inside the container even when accessing it interactively with `docker run -it ... sh`. Maybe the SportTracker container is intended to be used with an existing postgres-container.

In the end I made a workaround by creating a docker-compose.yaml with a separate postgres-container and pointing the flask server to the containerized postgres-database through the database-URI.
I am not an expert with docker (compose) and there might be more elegant solutions, but at least on my Raspberry Pi it is running fine that way. You may want to test the docker compose and merge it, if you consider this a useful addition.